### PR TITLE
fix bug of docs: `config.session` instead of  `session`

### DIFF
--- a/docs/zh/guide/session.md
+++ b/docs/zh/guide/session.md
@@ -162,7 +162,7 @@ class UserController extends Controller {
 ```js
 // config/config.default.js
 module.exports = {
-  session: {
+  config.session: {
     renew: true,
   },
 };


### PR DESCRIPTION
The configuration document information is incorrect.