### PR TITLE
fix(upload): stream-wormhole require issue

### DIFF
--- a/docs/zh/guide/upload.md
+++ b/docs/zh/guide/upload.md
@@ -130,7 +130,7 @@ class UploadController extends Controller {
 
 ```js
 const path = require('path');
-const sendToWormhole = require('stream-wormhole');
+const { sendToWormhole } = require('stream-wormhole');
 const Controller = require('egg').Controller;
 
 class UploadController extends Controller {
@@ -162,7 +162,7 @@ class UploadController extends Controller {
 同时上传多个文件的场景，不能通过 `ctx.getFileStream()` 来获取，只能通过以下方式：
 
 ```js
-const sendToWormhole = require('stream-wormhole');
+const { sendToWormhole } = require('stream-wormhole');
 const Controller = require('egg').Controller;
 
 class UploadController extends Controller {


### PR DESCRIPTION
stream-wormhole 在 v2.0.0 版本后变成以 esModule 的方式组织代码，打包出的 commonjs 默认导出好像有些问题，直接按文档代码使用会报错

``` js
const sendToWormhole = require('stream-wormhole');
await sendToWormhole(stream);
⬇️
nodejs.TypeError: sendToWormhole is not a function
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated code examples to use a consistent named import style for `sendToWormhole` in the upload guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->